### PR TITLE
chore(deps): 更新 renovate 配置以排除特定依赖- 移除了 ignoreDeps 中的 @dcloudio/* 和 !…

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,10 +5,15 @@
   "prConcurrentLimit": 0,
   "rangeStrategy": "bump",
   "ignoreDeps": [
-    "@dcloudio/*",
-    "!@dcloudio/types",
     "vite",
     "vue",
     "@vue/runtime-core"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["@dcloudio/*"],
+      "excludePackageNames": ["@dcloudio/types"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
…@dcloudio/types 条目

- 新增 packageRules 规则来禁用 @dcloudio/* 包的更新 -保留了对 @dcloudio/types 的更新支持
- 维持 vite、vue 和 @vue/runtime-core 的忽略规则