### PR TITLE
feat(hooks): 新增 useInstance 和 useEventChannel 钩子函数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 .idea
 docs/.vitepress/cache
 docs/.vitepress/dist
+.trae/specs

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -2,7 +2,7 @@ import type { RouteInterceptorOptions } from "uni-toolkit";
 import {
   chooseImageInterceptor,
   makePhoneCallInterceptor,
-  RouteInterceptor,
+  routeInterceptor,
   setClipboardDataInterceptor,
   setStorageInterceptor,
 } from "uni-toolkit";
@@ -14,7 +14,7 @@ import "virtual:uno.css";
 
 export function createApp(): any {
   const app = createSSRApp(App);
-  app.use<RouteInterceptorOptions>(RouteInterceptor, { loginRoute, isLogged, needLoginPages });
+  app.use<RouteInterceptorOptions>(routeInterceptor, { loginRoute, isLogged, needLoginPages });
   app.use(makePhoneCallInterceptor);
   app.use(chooseImageInterceptor);
   // #ifdef MP-KUAISHOU

--- a/playground/src/pages.json
+++ b/playground/src/pages.json
@@ -4,7 +4,9 @@
     { "path": "pages/need-login/index" },
     { "path": "pages/login/index" },
     { "path": "pages/choose-image/index", "style": { "navigationBarTitleText": "图片选择示例" } },
-    { "path": "pages/test-hooks", "style": { "navigationBarTitleText": "Hooks测试" } }
+    { "path": "pages/test-hooks", "style": { "navigationBarTitleText": "Hooks测试" } },
+    { "path": "pages/use-instance/index", "style": { "navigationBarTitleText": "useInstance示例" } },
+    { "path": "pages/use-event-channel/index", "style": { "navigationBarTitleText": "useEventChannel示例" } }
   ],
   "globalStyle": {
     "navigationBarTextStyle": "black",

--- a/playground/src/pages/index/index.vue
+++ b/playground/src/pages/index/index.vue
@@ -7,6 +7,12 @@ const data = ref({
 
 const selectedImages = ref<string[]>([]);
 
+// EventChannel 引用，用于后续再次发送数据
+const eventChannelRef = ref<WechatMiniprogram.EventChannel | null>(null);
+
+// 从接收页面收到的数据日志列表
+const eventChannelReceivedLogs = ref<string[]>([]);
+
 function makePhoneCall() {
   uni.makePhoneCall({
     phoneNumber: "10086",
@@ -93,6 +99,56 @@ function navigateToTestHooks() {
     url: "/pages/test-hooks",
   });
 }
+
+// 跳转到 EventChannel 示例页面
+function navigateToEventChannelDemo() {
+  uni.navigateTo({
+    url: "/pages/use-event-channel/index",
+    // 监听接收页面发来的事件
+    events: {
+      sendDataToOpenerPage: (data: { reply: string; timestamp: number }) => {
+        const time = new Date().toLocaleTimeString();
+        eventChannelReceivedLogs.value.unshift(
+          `[${time}] 收到回传: reply=${data.reply}, timestamp=${data.timestamp}`,
+        );
+        uni.showToast({
+          title: `收到回传: ${data.reply}`,
+          icon: "none",
+        });
+      },
+    },
+    success: (res) => {
+      // 保存 eventChannel 引用，用于后续再次发送
+      eventChannelRef.value = res.eventChannel;
+      // 通过 eventChannel 向接收页面发送初始数据
+      res.eventChannel.emit("acceptDataFromOpenerPage", {
+        id: 1,
+        name: "首页",
+        message: "来自首页的问候",
+      });
+    },
+  });
+}
+
+// 通过保存的 eventChannel 再次发送数据
+function sendDataToReceiver() {
+  if (!eventChannelRef.value) {
+    uni.showToast({
+      title: "EventChannel 不可用（请先跳转到示例页面）",
+      icon: "none",
+    });
+    return;
+  }
+  eventChannelRef.value.emit("acceptDataFromOpenerPage", {
+    id: Date.now(),
+    name: "首页(再次发送)",
+    message: `再次发送的数据 - ${new Date().toLocaleTimeString()}`,
+  });
+  uni.showToast({
+    title: "已再次发送数据",
+    icon: "success",
+  });
+}
 </script>
 
 <template>
@@ -134,6 +190,24 @@ function navigateToTestHooks() {
     <button @click="navigateToTestHooks">
       Hooks测试页面
     </button>
+    <button @click="navigateToEventChannelDemo">
+      EventChannel 示例
+    </button>
+    <button @click="sendDataToReceiver">
+      再次发送数据（EventChannel）
+    </button>
+
+    <!-- 显示从接收页面收到的回传数据 -->
+    <view v-if="eventChannelReceivedLogs.length > 0" class="mt-20">
+      <text class="block mb-10">
+        EventChannel 收到的回传数据：
+      </text>
+      <view class="log-list">
+        <view v-for="(log, index) in eventChannelReceivedLogs" :key="index" class="log-item">
+          {{ log }}
+        </view>
+      </view>
+    </view>
 
     <!-- 显示选择的图片 -->
     <view v-if="selectedImages.length > 0" class="mt-20">
@@ -185,5 +259,19 @@ function navigateToTestHooks() {
 }
 .pt-20 {
   padding-top: 20px;
+}
+.log-list {
+  margin-top: 10px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 10px;
+  background-color: #f5f5f5;
+  border-radius: 6px;
+}
+.log-item {
+  padding: 4px 0;
+  font-size: 12px;
+  color: #666;
+  border-bottom: 1px solid #f0f0f0;
 }
 </style>

--- a/playground/src/pages/test-hooks.vue
+++ b/playground/src/pages/test-hooks.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import { useChooseImage, useDesignSize, useOnShow } from "uni-toolkit";
 import { ref } from "vue";
-import { useChooseImage, useDesignSize, useOnShow } from "../../src/index";
 
 // 测试 useDesignSize
 const designSize = useDesignSize();

--- a/playground/src/pages/use-event-channel/index.vue
+++ b/playground/src/pages/use-event-channel/index.vue
@@ -1,0 +1,334 @@
+<script setup lang="ts">
+import { useEventChannel } from "uni-toolkit";
+import { onMounted, onUnmounted, ref } from "vue";
+
+// 定义事件数据类型映射（使用 type 而非 interface，符合 eslint 规则）
+type IMyEventMap = {
+  // 从上一个页面接收的数据事件
+  acceptDataFromOpenerPage: { id: number; name: string; message: string };
+  // 向上一个页面发送的数据事件
+  sendDataToOpenerPage: { reply: string; timestamp: number };
+};
+
+// 使用 useEventChannel 获取类型安全的 EventChannel
+const channel = useEventChannel<IMyEventMap>();
+
+// 是否成功获取 EventChannel
+const hasChannel = ref(false);
+
+// 是否已手动移除监听
+const isListenerOff = ref(false);
+
+// 从上一个页面接收到的数据
+const receivedData = ref<{ id: number; name: string; message: string } | null>(null);
+
+// 日志列表
+const logList = ref<string[]>([]);
+
+// 要发送的回复内容
+const replyContent = ref("收到啦～");
+
+// 添加日志
+function addLog(msg: string) {
+  const time = new Date().toLocaleTimeString();
+  logList.value.unshift(`[${time}] ${msg}`);
+}
+
+onMounted(() => {
+  if (channel) {
+    hasChannel.value = true;
+
+    // 使用 on 方法监听来自上一个页面的数据
+    channel.on("acceptDataFromOpenerPage", (data) => {
+      receivedData.value = data;
+      addLog(`[on] 收到数据: id=${data.id}, name=${data.name}, message=${data.message}`);
+    });
+
+    addLog("[on] 已注册 acceptDataFromOpenerPage 监听");
+  } else {
+    hasChannel.value = false;
+    addLog("EventChannel 获取失败（请通过 navigateTo 打开此页面）");
+  }
+});
+
+// 组件卸载时记录日志，验证自动清理监听器
+onUnmounted(() => {
+  console.log("[useEventChannel demo] 组件卸载，自动清理监听器");
+  addLog("[unmounted] 组件卸载，自动清理监听器");
+});
+
+// 向上一个页面发送数据（emit 演示）
+function emitToOpener() {
+  if (!channel) {
+    uni.showToast({ title: "EventChannel 不可用", icon: "none" });
+    return;
+  }
+
+  const data = {
+    reply: replyContent.value,
+    timestamp: Date.now(),
+  };
+
+  // 使用 emit 方法向上一个页面发送数据
+  channel.emit("sendDataToOpenerPage", data);
+  addLog(`[emit] 已发送数据: reply=${data.reply}, timestamp=${data.timestamp}`);
+
+  uni.showToast({ title: "发送成功", icon: "success" });
+}
+
+// 手动移除监听（off 演示）
+function offListener() {
+  if (!channel) {
+    uni.showToast({ title: "EventChannel 不可用", icon: "none" });
+    return;
+  }
+
+  if (isListenerOff.value) {
+    uni.showToast({ title: "监听已被移除，无需重复操作", icon: "none" });
+    return;
+  }
+
+  // 使用 off 方法手动移除 acceptDataFromOpenerPage 的所有监听
+  channel.off("acceptDataFromOpenerPage");
+  isListenerOff.value = true;
+  addLog("[off] 已手动移除 acceptDataFromOpenerPage 监听");
+
+  uni.showToast({ title: "监听已移除", icon: "none" });
+}
+
+// 返回上一页，触发组件卸载（自动卸载验证）
+function goBack() {
+  addLog("[navigateBack] 即将返回上一页，触发组件卸载...");
+  uni.navigateBack();
+}
+
+// 清空日志
+function clearLogs() {
+  logList.value = [];
+  receivedData.value = null;
+}
+
+// 从首页跳转到此页面（带 EventChannel 数据，用于演示）
+function navigateWithChannel() {
+  uni.navigateTo({
+    url: "/pages/use-event-channel/index",
+    success: (res) => {
+      // 通过 EventChannel 向新页面发送数据
+      res.eventChannel.emit("acceptDataFromOpenerPage", {
+        id: 1,
+        name: "主人",
+        message: "这是从上一个页面传来的数据哦～",
+      });
+    },
+  });
+}
+</script>
+
+<template>
+  <view class="container">
+    <view class="header">
+      useEventChannel 示例
+    </view>
+
+    <!-- EventChannel 状态提示 -->
+    <view class="section">
+      <view class="section-title">
+        EventChannel 状态
+      </view>
+      <view v-if="hasChannel" class="status-success">
+        ✅ EventChannel 获取成功
+      </view>
+      <view v-else class="status-fail">
+        ❌ EventChannel 获取失败
+      </view>
+      <view v-if="!hasChannel" class="tip">
+        💡 提示：此页面需要通过 uni.navigateTo 打开才能获取 EventChannel
+      </view>
+      <button v-if="!hasChannel" class="mt-10" @click="navigateWithChannel">
+        重新通过 navigateTo 打开此页面
+      </button>
+    </view>
+
+    <!-- on 监听演示 -->
+    <view class="section">
+      <view class="section-title">
+        接收数据（on 监听）
+      </view>
+      <view v-if="isListenerOff" class="status-fail">
+        ⚠️ 监听已被手动移除（off），不会再收到数据
+      </view>
+      <view v-if="receivedData" class="data-card">
+        <view>ID: {{ receivedData.id }}</view>
+        <view>姓名: {{ receivedData.name }}</view>
+        <view>消息: {{ receivedData.message }}</view>
+      </view>
+      <view v-else class="no-data">
+        暂无数据，等待上一个页面 emit...
+      </view>
+    </view>
+
+    <!-- emit 发送演示 -->
+    <view class="section">
+      <view class="section-title">
+        发送数据（emit）
+      </view>
+      <input
+        v-model="replyContent"
+        class="input"
+        placeholder="输入要回复的内容"
+      >
+      <button class="mt-10" @click="emitToOpener">
+        发送数据（emit）
+      </button>
+    </view>
+
+    <!-- off 手动移除演示 -->
+    <view class="section">
+      <view class="section-title">
+        手动移除监听（off）
+      </view>
+      <view class="desc">
+        点击后调用 channel.off("acceptDataFromOpenerPage")，移除后再发送数据将不再触发回调
+      </view>
+      <button
+        class="mt-10" :class="[isListenerOff ? 'btn-disabled' : '']"
+        :disabled="isListenerOff"
+        @click="offListener"
+      >
+        {{ isListenerOff ? "已移除监听" : "移除监听（off）" }}
+      </button>
+    </view>
+
+    <!-- 自动卸载验证 -->
+    <view class="section">
+      <view class="section-title">
+        自动卸载验证
+      </view>
+      <view class="desc">
+        点击返回上一页，组件卸载时 useEventChannel 会自动清理所有通过 on 注册的监听器，可在控制台和日志面板查看
+      </view>
+      <button class="mt-10 btn-warning" @click="goBack">
+        返回上一页（触发卸载）
+      </button>
+    </view>
+
+    <!-- 日志面板 -->
+    <view class="section">
+      <view class="section-title">
+        事件日志
+      </view>
+      <button size="mini" @click="clearLogs">
+        清空日志
+      </button>
+      <view v-if="logList.length > 0" class="log-list">
+        <view v-for="(log, index) in logList" :key="index" class="log-item">
+          {{ log }}
+        </view>
+      </view>
+      <view v-else class="no-data">
+        暂无日志
+      </view>
+    </view>
+  </view>
+</template>
+
+<style>
+.container {
+  padding: 20px;
+}
+
+.header {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.section {
+  margin-bottom: 30px;
+  padding: 15px;
+  border: 1px solid #eee;
+  border-radius: 8px;
+}
+
+.section-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.desc {
+  font-size: 13px;
+  color: #666;
+  line-height: 1.6;
+}
+
+.status-success {
+  color: #07c160;
+  font-weight: bold;
+}
+
+.status-fail {
+  color: #fa5151;
+  font-weight: bold;
+}
+
+.tip {
+  margin-top: 8px;
+  padding: 8px 12px;
+  background-color: #fff7e6;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #ed6a0c;
+}
+
+.data-card {
+  padding: 10px;
+  background-color: #f0f9eb;
+  border-radius: 6px;
+  border: 1px solid #e1f3d8;
+}
+
+.data-card view {
+  margin-bottom: 4px;
+  font-size: 14px;
+}
+
+.no-data {
+  color: #999;
+  font-size: 14px;
+}
+
+.input {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
+.mt-10 {
+  margin-top: 10px;
+}
+
+.btn-disabled {
+  opacity: 0.5;
+}
+
+.btn-warning {
+  background-color: #fa5151;
+  color: #fff;
+}
+
+.log-list {
+  margin-top: 10px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.log-item {
+  padding: 4px 0;
+  font-size: 12px;
+  color: #666;
+  border-bottom: 1px solid #f0f0f0;
+}
+</style>

--- a/playground/src/pages/use-instance/index.vue
+++ b/playground/src/pages/use-instance/index.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { useInstance } from "uni-toolkit";
+import { ref } from "vue";
+
+// 基础用法：获取组件实例
+const instance = useInstance();
+
+// 检测实例是否存在
+const hasInstance = ref(!!instance);
+
+// 检测 $props 是否存在
+const hasProps = ref(!!instance?.$props);
+
+// 检测 $el 是否存在
+const hasEl = ref(!!instance?.$el);
+
+// 使用 template ref 配合 useInstance 访问 DOM 元素
+const boxRef = ref<HTMLElement | null>(null);
+
+// 获取 ref 元素信息的响应式变量
+const refInfo = ref("点击下方按钮获取信息");
+
+// 通过 $refs 访问 DOM 元素
+function getRefInfo() {
+  if (instance && instance.$refs) {
+    const box = instance.$refs.boxRef as HTMLElement | undefined;
+    if (box) {
+      refInfo.value = `元素标签: ${box.tagName}, 宽度: ${box.clientWidth}px, 高度: ${box.clientHeight}px`;
+    } else {
+      refInfo.value = "未找到 ref 元素";
+    }
+  } else {
+    refInfo.value = "实例或 $refs 不存在";
+  }
+}
+
+// 泛型用法演示：定义自定义组件实例类型
+type MyComponentInstance = {
+  customMethod: () => string;
+  customData: number;
+};
+
+// 使用泛型获取实例（类型推断更精确）
+const typedInstance = useInstance<MyComponentInstance>();
+
+// 泛型实例信息
+const typedInfo = ref("点击下方按钮查看泛型实例信息");
+
+function checkTypedInstance() {
+  if (typedInstance) {
+    typedInfo.value = `泛型实例存在，可访问自定义属性：customMethod 类型=${typeof typedInstance.customMethod}, customData 类型=${typeof typedInstance.customData}`;
+  } else {
+    typedInfo.value = "泛型实例为 null";
+  }
+}
+</script>
+
+<template>
+  <view class="container">
+    <view class="header">
+      useInstance 示例
+    </view>
+
+    <!-- 基础用法：获取组件实例 -->
+    <view class="section">
+      <view class="section-title">
+        基础用法
+      </view>
+      <view>实例是否存在: {{ hasInstance ? '✅ 是' : '❌ 否' }}</view>
+      <view>$props 是否存在: {{ hasProps ? '✅ 是' : '❌ 否' }}</view>
+      <view>$el 是否存在: {{ hasEl ? '✅ 是' : '❌ 否' }}</view>
+    </view>
+
+    <!-- template ref 配合 $refs 访问 DOM -->
+    <view class="section">
+      <view class="section-title">
+        template ref + $refs 访问 DOM
+      </view>
+      <view
+        ref="boxRef"
+        class="demo-box"
+      >
+        我是一个可被 ref 引用的元素
+      </view>
+      <view class="info-text">
+        {{ refInfo }}
+      </view>
+      <button @click="getRefInfo">
+        获取 ref 元素信息
+      </button>
+    </view>
+
+    <!-- 泛型用法演示 -->
+    <view class="section">
+      <view class="section-title">
+        泛型用法
+      </view>
+      <view class="info-text">
+        {{ typedInfo }}
+      </view>
+      <button @click="checkTypedInstance">
+        检查泛型实例
+      </button>
+    </view>
+  </view>
+</template>
+
+<style>
+.container {
+  padding: 20px;
+}
+
+.header {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.section {
+  margin-bottom: 30px;
+  padding: 15px;
+  border: 1px solid #eee;
+  border-radius: 8px;
+}
+
+.section-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.demo-box {
+  width: 200px;
+  height: 80px;
+  background-color: #e8f4fd;
+  border: 2px solid #4fc3f7;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+  color: #0277bd;
+  font-size: 14px;
+}
+
+.info-text {
+  margin: 10px 0;
+  padding: 8px;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #666;
+}
+</style>

--- a/src/hooks/index.md
+++ b/src/hooks/index.md
@@ -5,8 +5,10 @@ Hooks 是基于 Vue 3 Composition API 封装的常用功能，简化组件开发
 ## 目录
 
 - [useChooseImage](./useChooseImage) - 封装图片选择功能
-- [useOnShow](./useOnShow) - 统一的页面显示事件钩子
 - [useDesignSize](./useDesignSize) - 获取设计尺寸信息
+- [useEventChannel](./useEventChannel) - 页面间 EventChannel 通信
+- [useInstance](./useInstance) - 获取组件实例 proxy 对象
+- [useOnShow](./useOnShow) - 统一的页面显示事件钩子
 
 ## 概述
 
@@ -14,11 +16,13 @@ uni-toolkit 提供了一系列实用的 Hooks，帮助开发者简化组件开�
 
 ### 主要 Hooks
 
-| Hook             | 功能描述             | 适用场景                       |
-| ---------------- | -------------------- | ------------------------------ |
-| `useChooseImage` | 简化图片选择流程     | 需要选择图片的组件             |
-| `useDesignSize`  | 响应式设计尺寸处理   | 需要响应式布局的组件           |
-| `useOnShow`      | 页面显示生命周期处理 | 需要在页面显示时执行操作的组件 |
+| Hook              | 功能描述                 | 适用场景                       |
+| ----------------- | ------------------------ | ------------------------------ |
+| `useChooseImage`  | 简化图片选择流程         | 需要选择图片的组件             |
+| `useDesignSize`   | 响应式设计尺寸处理       | 需要响应式布局的组件           |
+| `useEventChannel` | 页面间 EventChannel 通信 | 需要页面间传递数据的页面       |
+| `useInstance`     | 获取组件实例 proxy       | 需要访问组件实例的组件         |
+| `useOnShow`       | 页面显示生命周期处理     | 需要在页面显示时执行操作的组件 |
 
 ### 使用方式
 
@@ -45,7 +49,7 @@ function handleChooseImage() {
 
 ```javascript
 // 按需导入hooks
-import { useChooseImage, useDesignSize, useOnShow } from "uni-toolkit/hooks";
+import { useChooseImage, useDesignSize, useEventChannel, useInstance, useOnShow } from "uni-toolkit/hooks";
 ```
 
 每个 Hook 都有详细的文档和使用示例，您可以通过上方的链接查看具体信息。

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export { useChooseImage } from "./useChooseImage";
 export { useDesignSize } from "./useDesignSize";
+export { useEventChannel } from "./useEventChannel";
+export { useInstance } from "./useInstance";
 export { useOnShow } from "./useOnShow";

--- a/src/hooks/useEventChannel/index.md
+++ b/src/hooks/useEventChannel/index.md
@@ -1,0 +1,118 @@
+# useEventChannel
+
+封装获取 EventChannel 并提供类型安全的 on/emit/off 便捷方法，用于页面间通信，监听上一个页面通过 EventChannel 传递的数据。需要在页面的 setup 中使用，且页面由 navigateTo 打开。组件卸载时会自动清理通过 on 注册的所有监听器。
+
+## 平台支持
+
+全平台
+
+## 泛型参数
+
+| 参数 | 约束                     | 默认值           | 说明                                             |
+| ---- | ------------------------ | ---------------- | ------------------------------------------------ |
+| T    | extends IEventChannelMap | IEventChannelMap | 事件数据类型映射，定义事件名与数据类型的对应关系 |
+
+## 返回值
+
+`IEventChannelActions<T> | undefined` — 包含 on/emit/off 的类型安全对象，获取 EventChannel 失败时返回 undefined
+
+## IEventChannelActions 方法
+
+| 方法 | 签名                                                                            | 说明               |
+| ---- | ------------------------------------------------------------------------------- | ------------------ |
+| on   | `<K extends keyof T>(event: K, callback: IEventChannelCallback<T[K]>) => void`  | 类型安全的事件监听 |
+| emit | `<K extends keyof T>(event: K, data: T[K]) => void`                             | 类型安全的事件发送 |
+| off  | `<K extends keyof T>(event: K, callback?: IEventChannelCallback<T[K]>) => void` | 类型安全的事件移除 |
+
+## 相关类型
+
+- `IEventChannelMap` — 事件数据类型映射接口，`Record<string, unknown>`
+- `IEventChannelCallback<T>` — 事件回调函数类型，`(data: T) => void`
+
+## 使用示例
+
+### 基础用法
+
+```typescript
+import { useEventChannel } from "uni-toolkit";
+
+export default {
+  setup() {
+    const channel = useEventChannel();
+
+    channel?.on("acceptDataFromOpenerPage", (data) => {
+      console.log("收到数据:", data);
+    });
+
+    return {};
+  }
+};
+```
+
+### 带类型约束的用法
+
+```typescript
+import type { IEventChannelMap } from "uni-toolkit";
+import { useEventChannel } from "uni-toolkit";
+
+// 定义事件数据类型映射
+type IMyEventMap = {
+  acceptDataFromOpenerPage: { id: number; name: string };
+  someOtherEvent: { message: string };
+} & IEventChannelMap;
+
+export default {
+  setup() {
+    const channel = useEventChannel<IMyEventMap>();
+
+    // on — 类型安全，data 自动推导为 { id: number; name: string }
+    channel?.on("acceptDataFromOpenerPage", (data) => {
+      console.log("收到数据:", data.id, data.name);
+    });
+
+    // emit — 类型安全，data 必须匹配对应事件的数据类型
+    channel?.emit("someOtherEvent", { message: "hello" });
+
+    // off — 类型安全移除监听
+    const handler = (data: { id: number; name: string }) => { /* ... */ };
+    channel?.off("acceptDataFromOpenerPage", handler);
+
+    // 组件卸载时自动清理，无需手动 off
+    return {};
+  }
+};
+```
+
+### 发送页面配合使用
+
+```typescript
+// 发送页面（上一个页面）
+uni.navigateTo({
+  url: "/pages/detail/index",
+  events: {
+    acceptDataFromOpenedPage: (data) => {
+      console.log("收到下级页面数据:", data);
+    }
+  },
+  success(res) {
+    // 通过 EventChannel 向下级页面发送数据
+    res.eventChannel.emit("acceptDataFromOpenerPage", { id: 1, name: "测试" });
+  }
+});
+```
+
+## 特性
+
+- 封装 `getOpenerEventChannel` 调用，简化 EventChannel 获取
+- 提供类型安全的 on/emit/off 便捷方法，替代原始 EventChannel 操作
+- 支持泛型事件映射，事件名和数据类型完全约束
+- 组件卸载时自动清理通过 on 注册的所有监听器，防止内存泄漏
+- 开发环境下，获取 EventChannel 失败时输出 console.warn 警告
+
+## 注意事项
+
+1. 必须在页面的 setup 函数中调用
+2. 当前页面必须由 `uni.navigateTo` 打开，否则无法获取 EventChannel
+3. 开发环境下，如果获取 EventChannel 失败，控制台会输出警告信息
+4. 通过 on 注册的监听器会在组件卸载时自动清理，无需手动 off
+5. 如果需要手动移除某个监听器，可以使用 off 方法

--- a/src/hooks/useEventChannel/index.ts
+++ b/src/hooks/useEventChannel/index.ts
@@ -1,0 +1,134 @@
+import { getCurrentInstance, onUnmounted } from "vue";
+
+/**
+ * EventChannel 数据类型映射接口
+ * 用于定义不同事件名称对应的数据类型
+ */
+export type IEventChannelMap = Record<string, unknown>;
+
+/**
+ * EventChannel 监听回调函数类型
+ * @template T - 接收的数据类型
+ */
+export type IEventChannelCallback<T = unknown> = (data: T) => void;
+
+/**
+ * useEventChannel 返回的类型安全的便捷方法对象
+ */
+export type IEventChannelActions<T extends IEventChannelMap = IEventChannelMap> = {
+  /** 类型安全的事件监听 */
+  on: <K extends keyof T>(event: K, callback: IEventChannelCallback<T[K]>) => void;
+  /** 类型安全的事件发送 */
+  emit: <K extends keyof T>(event: K, data: T[K]) => void;
+  /** 类型安全的事件移除 */
+  off: <K extends keyof T>(event: K, callback?: IEventChannelCallback<T[K]>) => void;
+};
+
+/**
+ * 封装获取 EventChannel 并提供类型安全的 on/emit/off 便捷方法
+ *
+ * @description
+ * 用于页面间通信，监听上一个页面通过 EventChannel 传递的数据。
+ * 需要在页面的 setup 中使用，且页面由 navigateTo 打开。
+ * 组件卸载时会自动清理通过 on 注册的所有监听器。
+ *
+ * @template T - 事件数据类型映射，默认为 IEventChannelMap
+ * @returns 返回包含 on/emit/off 的类型安全对象，获取 EventChannel 失败时返回 undefined
+ *
+ * @example
+ * ```typescript
+ * // 定义事件数据类型映射
+ * interface IMyEventMap {
+ *   acceptDataFromOpenerPage: { id: number; name: string };
+ *   someOtherEvent: { message: string };
+ * }
+ *
+ * // 使用 hook 监听事件（带类型约束）
+ * const channel = useEventChannel<IMyEventMap>();
+ *
+ * // on — 类型安全，data 自动推导为 { id: number; name: string }
+ * channel?.on("acceptDataFromOpenerPage", (data) => {
+ *   console.log("收到数据:", data.id, data.name);
+ * });
+ *
+ * // emit — 类型安全，data 必须匹配对应事件的数据类型
+ * channel?.emit("someOtherEvent", { message: "hello" });
+ *
+ * // off — 类型安全移除监听
+ * const handler = (data: { id: number; name: string }) => { /* ... *\/ };
+ * channel?.off("acceptDataFromOpenerPage", handler);
+ *
+ * // 组件卸载时自动清理，无需手动 off
+ * ```
+ */
+export function useEventChannel<T extends IEventChannelMap = IEventChannelMap>(): IEventChannelActions<T> | undefined {
+  // 获取当前组件实例（使用 as any 因为 getOpenerEventChannel 是 uni-app 扩展属性）
+  const instance = getCurrentInstance()?.proxy as any;
+
+  // 获取打开当前页面的 EventChannel
+  const eventChannel = instance?.getOpenerEventChannel?.() as UniApp.EventChannel | undefined;
+
+  // 获取失败时在开发环境输出警告
+  if (!eventChannel) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn("[uni-toolkit] useEventChannel 获取 EventChannel 失败，请确保在页面 setup 中调用且页面由 navigateTo 打开");
+    }
+    return undefined;
+  }
+
+  // 监听器映射表，用于跟踪所有通过 on 注册的回调，以便卸载时自动清理
+  const listenerMap = new Map<keyof T, Set<IEventChannelCallback>>();
+
+  /**
+   * 类型安全的事件监听
+   * @param event - 事件名称
+   * @param callback - 事件回调函数
+   */
+  function on<K extends keyof T>(event: K, callback: IEventChannelCallback<T[K]>): void {
+    // 在原始 EventChannel 上注册监听（此时 eventChannel 必定存在，因为不存在时已提前 return）
+    eventChannel!.on(event as string, callback as IEventChannelCallback);
+
+    // 将回调记录到映射表中，便于后续自动清理
+    if (!listenerMap.has(event)) {
+      listenerMap.set(event, new Set());
+    }
+    listenerMap.get(event)!.add(callback as IEventChannelCallback);
+  }
+
+  /**
+   * 类型安全的事件发送
+   * @param event - 事件名称
+   * @param data - 发送的数据
+   */
+  function emit<K extends keyof T>(event: K, data: T[K]): void {
+    eventChannel!.emit(event as string, data);
+  }
+
+  /**
+   * 类型安全的事件移除
+   * @param event - 事件名称
+   * @param callback - 可选，指定要移除的回调函数；不传则移除该事件的所有回调
+   */
+  function off<K extends keyof T>(event: K, callback?: IEventChannelCallback<T[K]>): void {
+    eventChannel!.off(event as string, callback as IEventChannelCallback);
+
+    // 同步清理映射表中的记录
+    if (callback) {
+      listenerMap.get(event)?.delete(callback as IEventChannelCallback);
+    } else {
+      listenerMap.delete(event);
+    }
+  }
+
+  // 组件卸载时自动清理所有通过 on 注册的监听器
+  onUnmounted(() => {
+    listenerMap.forEach((callbacks, event) => {
+      callbacks.forEach((cb) => {
+        eventChannel!.off(event as string, cb);
+      });
+    });
+    listenerMap.clear();
+  });
+
+  return { on, emit, off };
+}

--- a/src/hooks/useInstance/index.md
+++ b/src/hooks/useInstance/index.md
@@ -1,0 +1,66 @@
+# useInstance
+
+获取当前组件实例的 proxy 对象，封装了 `getCurrentInstance().proxy` 逻辑，用于在组件内部获取组件实例的代理对象。支持泛型参数以获得更精确的类型推断。
+
+## 平台支持
+
+全平台
+
+## 类型参数
+
+| 参数 | 约束                    | 默认值                  | 说明                       |
+| ---- | ----------------------- | ----------------------- | -------------------------- |
+| T    | ComponentPublicInstance | ComponentPublicInstance | 组件实例类型，用于类型推断 |
+
+## 参数
+
+无参数
+
+## 返回值
+
+`T | null` — 组件实例的 proxy 对象，如果不在组件上下文中调用则返回 null
+
+## 使用示例
+
+### 基础用法
+
+```typescript
+import { useInstance } from "uni-toolkit";
+
+export default {
+  setup() {
+    const instance = useInstance();
+    if (instance) {
+      console.log(instance.$props);
+      console.log(instance.$el);
+    }
+    return {};
+  }
+};
+```
+
+### 泛型用法
+
+```typescript
+import { useInstance } from "uni-toolkit";
+
+// 传入自定义组件类型，获得精确的类型推断
+const instance = useInstance<MyComponent>();
+if (instance) {
+  // 可以直接访问组件自定义属性和方法，无需类型断言
+  instance.customMethod();
+}
+```
+
+## 特性
+
+- 封装 `getCurrentInstance().proxy` 逻辑，简化组件实例获取
+- 支持泛型参数，可传入组件类型获得精确的类型推断
+- 开发环境下，非 setup 上下文调用时输出 console.warn 警告
+- 不在组件上下文中调用时安全返回 null
+
+## 注意事项
+
+1. 必须在 setup 函数中调用，不能在异步回调（如 setTimeout、Promise.then）中使用
+2. 开发环境下，如果在非 setup 上下文中调用，控制台会输出警告信息
+3. 建议使用泛型参数以获得更好的类型提示

--- a/src/hooks/useInstance/index.ts
+++ b/src/hooks/useInstance/index.ts
@@ -1,0 +1,45 @@
+import type { ComponentPublicInstance } from "vue";
+import { getCurrentInstance } from "vue";
+
+/**
+ * 获取当前组件实例的 proxy 对象
+ *
+ * 该 hook 封装了 getCurrentInstance().proxy 逻辑，
+ * 用于在组件内部获取组件实例的代理对象。
+ *
+ * 支持传入泛型参数以获得更精确的类型推断。
+ * 在开发环境下，如果不在 setup 函数中调用，会输出警告信息。
+ *
+ * @template T - 组件实例类型，默认为 ComponentPublicInstance
+ * @returns 组件实例的 proxy 对象，如果不在组件上下文中调用则返回 null
+ *
+ * @example
+ * ```ts
+ * // 基础用法
+ * const instance = useInstance();
+ * if (instance) {
+ *   console.log(instance.$props);
+ * }
+ *
+ * // 传入自定义组件类型，获得精确的类型推断
+ * const instance = useInstance<MyComponent>();
+ * if (instance) {
+ *   console.log(instance.customMethod());
+ * }
+ * ```
+ */
+export function useInstance<T = ComponentPublicInstance>(): T | null {
+  // 获取当前组件实例
+  const instance = getCurrentInstance();
+
+  // 如果不在组件上下文中调用，返回 null 并在开发环境下输出警告
+  if (!instance) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn("[uni-toolkit] useInstance 必须在 setup 函数中调用");
+    }
+    return null;
+  }
+
+  // 返回组件实例的 proxy 对象
+  return instance.proxy as T | null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export { isMpWeiXinWork } from "./env";
 export {
   useChooseImage,
   useDesignSize,
+  useEventChannel,
+  useInstance,
   useOnShow,
 } from "./hooks";
 


### PR DESCRIPTION
新增 useInstance 钩子用于获取组件实例 proxy 对象，支持泛型类型推断
新增 useEventChannel 钩子封装页面间 EventChannel 通信，提供类型安全方法 更新文档和示例页面展示新钩子用法

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 新增 `useEventChannel` Hook：支持页面间事件通信，提供类型安全的 `on/emit/off` 便捷方法
  * 新增 `useInstance` Hook：支持获取组件实例代理，提供泛型类型推断

* **文档**
  * 完善 Hooks 文档索引，新增两个 Hook 的详细使用说明和示例代码

* **示例**
  * 新增演示页面展示 `useEventChannel` 和 `useInstance` 的具体用法

<!-- end of auto-generated comment: release notes by coderabbit.ai -->