### PR TITLE
refactor(useEventChannel): 优化类型导出和文档示例

### DIFF
--- a/playground/src/pages/index/index.vue
+++ b/playground/src/pages/index/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { IEventChannelActions, IEventChannelMap } from "uni-toolkit";
+import type { IEventChannelActions } from "uni-toolkit/hooks";
 import { createEventChannelActions } from "uni-toolkit";
 import { ref } from "vue";
 
@@ -7,7 +7,7 @@ import { ref } from "vue";
 type IMyEventMap = {
   acceptDataFromOpenerPage: { id: number; name: string; message: string };
   sendDataToOpenerPage: { reply: string; timestamp: number };
-} & IEventChannelMap;
+};
 
 const data = ref({
   data: "Hello World",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useChooseImage } from "./useChooseImage";
 export { useDesignSize } from "./useDesignSize";
 export { createEventChannelActions, useEventChannel } from "./useEventChannel";
+export { type IEventChannelActions } from "./useEventChannel";
 export { useInstance } from "./useInstance";
 export { useOnShow } from "./useOnShow";

--- a/src/hooks/useEventChannel/index.md
+++ b/src/hooks/useEventChannel/index.md
@@ -29,14 +29,13 @@
 ### 使用示例
 
 ```typescript
-import type { IEventChannelMap } from "uni-toolkit";
 import { createEventChannelActions } from "uni-toolkit";
 
 // 定义事件数据类型映射
 type IMyEventMap = {
   acceptDataFromOpenerPage: { id: number; name: string };
   sendDataToOpenerPage: { reply: string; timestamp: number };
-} & IEventChannelMap;
+};
 
 uni.navigateTo({
   url: "/pages/detail/index",
@@ -100,14 +99,13 @@ export default {
 ### 带类型约束的用法
 
 ```typescript
-import type { IEventChannelMap } from "uni-toolkit";
 import { useEventChannel } from "uni-toolkit";
 
 // 定义事件数据类型映射
 type IMyEventMap = {
   acceptDataFromOpenerPage: { id: number; name: string };
   someOtherEvent: { message: string };
-} & IEventChannelMap;
+};
 
 export default {
   setup() {
@@ -134,7 +132,6 @@ export default {
 ### 发送页面配合使用
 
 ```typescript
-import type { IEventChannelMap } from "uni-toolkit";
 // 发送页面（上一个页面）
 import { createEventChannelActions } from "uni-toolkit";
 
@@ -142,7 +139,7 @@ import { createEventChannelActions } from "uni-toolkit";
 type IMyEventMap = {
   acceptDataFromOpenerPage: { id: number; name: string };
   sendDataToOpenerPage: { reply: string; timestamp: number };
-} & IEventChannelMap;
+};
 
 uni.navigateTo({
   url: "/pages/detail/index",

--- a/src/hooks/useEventChannel/index.ts
+++ b/src/hooks/useEventChannel/index.ts
@@ -31,6 +31,32 @@ export type IEventChannelActions<T extends IEventChannelMap = IEventChannelMap> 
  * @template T - 事件数据类型映射，需继承 IEventChannelMap
  * @param eventChannel - 原始 EventChannel 实例
  * @returns 返回包含 on/emit/off 的类型安全对象
+ *
+ * @example
+ * ```typescript
+ * // 定义事件数据类型映射
+ * interface IMyEventMap {
+ *   acceptDataFromOpenerPage: { id: number; name: string };
+ *   someOtherEvent: { message: string };
+ * }
+ *
+ * // 获取 EventChannel 实例（如从页面跳转参数中获取）
+ * const eventChannel = getOpenerEventChannel();
+ *
+ * // 创建类型安全的操作方法
+ * const { on, emit, off } = createEventChannelActions<IMyEventMap>(eventChannel);
+ *
+ * // on — 类型安全监听
+ * on("acceptDataFromOpenerPage", (data) => {
+ *   console.log("收到数据:", data.id, data.name);
+ * });
+ *
+ * // emit — 类型安全发送
+ * emit("someOtherEvent", { message: "hello" });
+ *
+ * // off — 类型安全移除
+ * off("acceptDataFromOpenerPage");
+ * ```
  */
 export function createEventChannelActions<T extends IEventChannelMap = IEventChannelMap>(
   eventChannel: UniApp.EventChannel,


### PR DESCRIPTION
1.  导出IEventChannelActions类型供外部使用
2.  移除冗余的IEventChannelMap继承引用
3.  为createEventChannelActions添加完整使用示例
4.  更新示例代码中的类型定义写法